### PR TITLE
make sure to call balanceChanged callback whenever balance is updated

### DIFF
--- a/BRWallet.c
+++ b/BRWallet.c
@@ -968,6 +968,9 @@ void BRWalletUpdateTransactions(BRWallet *wallet, const UInt256 txHashes[], size
     
     if (needsUpdate) _BRWalletUpdateBalance(wallet);
     pthread_mutex_unlock(&wallet->lock);
+    if (needsUpdate && wallet->balanceChanged) {
+        wallet->balanceChanged(wallet->callbackInfo, wallet->balance);
+    }
     if (j > 0 && wallet->txUpdated) wallet->txUpdated(wallet->callbackInfo, hashes, j, blockHeight, timestamp);
 }
 
@@ -992,6 +995,9 @@ void BRWalletSetTxUnconfirmedAfter(BRWallet *wallet, uint32_t blockHeight)
     
     if (count > 0) _BRWalletUpdateBalance(wallet);
     pthread_mutex_unlock(&wallet->lock);
+    if (count > 0 && wallet->balanceChanged) {
+        wallet->balanceChanged(wallet->callbackInfo, wallet->balance);
+    }
     if (count > 0 && wallet->txUpdated) wallet->txUpdated(wallet->callbackInfo, hashes, count, TX_UNCONFIRMED, 0);
 }
 


### PR DESCRIPTION
yesterday I have seen this issue litecoin-foundation/loafwallet-android#117 on iOS.