### PR TITLE
bech32 changes

### DIFF
--- a/BRPeerManager.c
+++ b/BRPeerManager.c
@@ -1632,6 +1632,15 @@ void BRPeerManagerSetFixedPeer(BRPeerManager *manager, UInt128 address, uint16_t
     pthread_mutex_unlock(&manager->lock);
 }
 
+uint16_t BRPeerManagerStandardPort(BRPeerManager *manager)
+{
+    assert(manager != NULL);
+    pthread_mutex_lock(&manager->lock);
+    uint16_t port = manager->params->standardPort;
+    pthread_mutex_unlock(&manager->lock);
+    return port;
+}
+
 // current connect status
 BRPeerStatus BRPeerManagerConnectStatus(BRPeerManager *manager)
 {

--- a/BRPeerManager.h
+++ b/BRPeerManager.h
@@ -72,6 +72,9 @@ void BRPeerManagerSetFixedPeer(BRPeerManager *manager, UInt128 address, uint16_t
 // current connect status
 BRPeerStatus BRPeerManagerConnectStatus(BRPeerManager *manager);
 
+// returns the standard port used for BRChainParams
+uint16_t BRPeerManagerStandardPort(BRPeerManager *manager);
+
 // connect to bitcoin peer-to-peer network (also call this whenever networkIsReachable() status changes)
 void BRPeerManagerConnect(BRPeerManager *manager);
 


### PR DESCRIPTION
This PR updates secp256k1 & adds a function to return the network's standard port. These changes allow us to use a single branch of `loafwallet-core`, unifying changes, which will greatly simplify future feature additions e.g. segwit.

Recommended to rebase and merge.