### PR TITLE
🦺[Tech Debt] Resets the fpRate to the reduced rate to reset

### DIFF
--- a/BRPeerManager.c
+++ b/BRPeerManager.c
@@ -1207,6 +1207,10 @@ static void _peerRelayedBlock(void *info, BRMerkleBlock *block)
             manager->fpRate > BLOOM_DEFAULT_FALSEPOSITIVE_RATE*10.0) {
             peer_log(peer, "bloom filter false positive rate %f too high after %"PRIu32" blocks, disconnecting...",
                      manager->fpRate, manager->lastBlock->height + 1 - manager->filterUpdateHeight);
+
+            //Resets the fpRate to the reduced fpRate to allow further connection
+            manager->fpRate = BLOOM_REDUCED_FALSEPOSITIVE_RATE;
+
             BRPeerDisconnect(peer);
         }
         else if (manager->lastBlock->height + 500 < BRPeerLastBlock(peer) &&


### PR DESCRIPTION
# Why?
Near the end of the sync cycle, the fpRate degrades so much that it fails to connect reliably.  This change resets to the default reduced rate so the sync can continue.

# Test results

Using the built in analytics we are now tracking the amount of time it takes to sync

Firebase Analytics: [did_complete_sync](https://console.firebase.google.com/u/0/project/litewallet-beta/analytics/app/android:com.loafwallet/events/~2Foverview%3Ft%3D1680941678694&fpn%3D230187998656&swu%3D1&sgu%3D1&sus%3Dupgraded&params%3D_u..pageSize%253D25%2526_r..layout.pageNumber%253D0&cs%3Dapp.m.events.overview&g%3D1)